### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -1,5 +1,8 @@
 name: NodeJS with Webpack
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Lara-Global/Payment-Gateway/security/code-scanning/1](https://github.com/Lara-Global/Payment-Gateway/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily involves checking out the repository, setting up Node.js, and building the project using Webpack, it only requires read access to the repository contents. Therefore, the `permissions` block should be added at the root level of the workflow to apply to all jobs, with `contents: read` as the minimal required permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
